### PR TITLE
feat: interview 질문 데이터 REST-API range로 랜덤 4건만 조회하도록 리팩터링

### DIFF
--- a/src/api/questionAPI.ts
+++ b/src/api/questionAPI.ts
@@ -4,12 +4,25 @@ import { supabase } from '../supabaseClient';
 export const getQuestionsByCategoryAndTopic = async (
   category: string,
   topic: string,
+  limit = 4,
 ) => {
-  const { data, error } = await supabase
+  const { count, error: countError } = await supabase
     .from('questions')
-    .select('*')
+    .select('*', { count: 'exact', head: true })
     .eq('category', category)
     .eq('topic', topic);
+
+  if (countError) throw countError;
+
+  const maxOffset = Math.max(0, (count ?? 0) - limit);
+  const offset = Math.floor(Math.random() * (maxOffset + 1));
+
+  const { data, error } = await supabase
+    .from('questions')
+    .select('question_id, category, topic, content')
+    .eq('category', category)
+    .eq('topic', topic)
+    .range(offset, offset + limit - 1);
 
   if (error) throw error;
   return data;

--- a/src/page/InterviewPage.tsx
+++ b/src/page/InterviewPage.tsx
@@ -50,21 +50,14 @@ export default function InterviewPage() {
   );
 
   /* 즐겨찾기(bookmark) 등록 부분 */
+
   // 유저 아이디 불러오기
   const user_id = useUserDataStore((state) => state.userData.user_id);
   const [isBookMarked, setIsBookMarked] = useState<boolean>(false);
 
-  // 추가 질문 랜덤 함수
-  function getRandomItems<T>(array: T[], count: number): T[] {
-    const shuffled = [...array].sort(() => 0.5 - Math.random());
-    return shuffled.slice(0, count);
-  }
-
   // 질문 불러오기 get요청
   const fetchQuestion = useCallback(async () => {
-    // API 요청 확인용
-    console.log('rawCategory:', rawCategory, 'topicParam:', topicParam);
-
+    // 유효성 체크
     if (!isCategoryKey(rawCategory) || !topicParam) {
       setQuestion({
         questionId: 0,
@@ -75,51 +68,73 @@ export default function InterviewPage() {
       setFollowUpQuestions([]);
       return;
     }
-
     try {
       const data = await getQuestionsByCategoryAndTopic(
-        rawCategory,
-        topicParam,
+        rawCategory!,
+        topicParam!,
+        4,
       );
       // API 요청 확인용
+      console.log('rawCategory:', rawCategory, 'topicParam:', topicParam);
       console.log('불러온 질문 수:', data.length);
       console.log('data 내용:', data);
 
       if (!data.length) throw new Error('질문 없음');
 
-      const idx = Math.floor(Math.random() * data.length);
-      const pick = data[idx];
+      const [main, ...others] = data;
 
+      // try {
+      //   const data = await getQuestionsByCategoryAndTopic(
+      //     rawCategory,
+      //     topicParam,
+      //   );
+      //   // API 요청 확인용
+      //   console.log('불러온 질문 수:', data.length);
+      //   console.log('data 내용:', data);
+
+      //   if (!data.length) throw new Error('질문 없음');
+
+      //   const idx = Math.floor(Math.random() * data.length);
+      //   const pick = data[idx];
+
+      // 메인 질문 세팅
       setQuestion({
-        questionId: pick.question_id,
-        category: rawCategory as CategoryKey,
-        topic: pick.topic,
-        question: pick.content,
+        questionId: main.question_id,
+        category: main.category as CategoryKey,
+        topic: main.topic,
+        question: main.content,
       });
 
       // 추가 질문 나머지 질문 목록에서 랜덤으로 3개 뽑기
-      const otherQuestion = data
-        .filter((_, i) => i !== idx)
-        .map((q) => ({
+
+      // const otherQuestion = data
+      //   .filter((_, i) => i !== idx)
+      //   .map((q) => ({
+      //     questionId: q.question_id,
+      //     category: rawCategory as CategoryKey,
+      //     topic: q.topic,
+      //     question: q.content,
+      //   }));
+
+      // 추가 질문 세팅
+      setFollowUpQuestions(
+        others.map((q) => ({
           questionId: q.question_id,
-          category: rawCategory as CategoryKey,
+          category: q.category as CategoryKey,
           topic: q.topic,
           question: q.content,
-        }));
+        })),
+      );
 
-      setFollowUpQuestions(getRandomItems(otherQuestion, 3));
-
-      if (isFirstLoad.current) {
-        isFirstLoad.current = false;
-      } else {
-        toast('새로운 질문이 도착했어요!', 'success');
-      }
+      // 토스트 메시지
+      if (isFirstLoad.current) isFirstLoad.current = false;
+      else toast('새로운 질문이 도착했어요!', 'success');
     } catch (e) {
       console.error(e);
       setQuestion({
         questionId: 0,
         category: rawCategory as CategoryKey,
-        topic: topicParam || '',
+        topic: topicParam,
         question: '질문을 불러오는 데 실패했습니다.',
       });
       setFollowUpQuestions([]);


### PR DESCRIPTION
### 변경 내용
 - 기존 : category/topic 조건에 맞는 모든 질문을 가져온 뒤 클라이언트에서 랜덤으로 4개만 사용,
 - 변경 : 
    1. 총 행 수 (count) 확인 랜덤으로 offset 계산
    2. range(offset, offest+3) 로 DB에서 4건만 호출
    3. interviewpage에서 메인 질문 1개와 추가질문 3개 적용