### PR TITLE
fix: 이미지 전체에 적용된 cursor-pointer 제거 및 섹션별 포인터 커서 정상화

### DIFF
--- a/src/components/mainpage/UserMain.tsx
+++ b/src/components/mainpage/UserMain.tsx
@@ -66,10 +66,7 @@ export default function UserMain() {
         <div className="flex justify-center w-full ">
           <div className="grid grid-cols-3 gap-10 text-center w-full ">
             {topics.map((topic) => (
-              <div
-                key={topic.category}
-                className="flex flex-col gap-5 cursor-pointer"
-              >
+              <div key={topic.category} className="flex flex-col gap-5">
                 <div>
                   <p className={`font-semibold text-lg ${topic.colorClass}`}>
                     {topic.category}


### PR DESCRIPTION
<img width="694" height="294" alt="image" src="https://github.com/user-attachments/assets/c9ec4b8a-4cfd-4f30-a5fd-75f7e85619a0" />

이미지 전체 영역에 걸려 있던 cursor-pointer 스타일을 제거

각 주제별 요소에만 포인터 커서가 적용되도록 수정하여 UX 개선