### PR TITLE
fix: 프로필 수정 후 userData 동기화하여 되돌리기 버그 해결

### DIFF
--- a/src/components/mypage/Profile.tsx
+++ b/src/components/mypage/Profile.tsx
@@ -106,12 +106,6 @@ export default function Profile() {
     setSelectedImageFile(null);
   };
 
-  // 수정 모드 해제
-  // const endEditing = () => {
-  //   resetForm();
-  //   setIsEditing(false);
-  // };
-
   const saveChanges = async () => {
     if (!userData) return;
 
@@ -130,6 +124,16 @@ export default function Profile() {
         ...formData,
         profile_img,
       });
+
+      // 프로필 수정하고, 새로고침 없이 되돌리기 했을 때 이전 데이터 나오길래 수정
+      const newUser = {
+        ...userData,
+        ...formData,
+        profile_img,
+      };
+      setUserData(newUser);
+      setFormData(newUser);
+      setPreviewImg(profile_img || defaultProfileImg);
 
       useUserDataStore.getState().setUserData({
         ...storeUserData,


### PR DESCRIPTION
프로필을 수정한 뒤 [저장하기]를 누르고 바로 [되돌리기] 를 클릭하면, 
실제로 저장이 완료되지 않아 예전 정보(수정 전 데이터)가 다시 보이는 이슈

해당 이슈 newUser 라는 변수로 정보 최신화 함