### PR TITLE
[refactor/#136] 히스토리 수정 버튼 텍스트 수정

### DIFF
--- a/src/components/mypage/InterviewHistory.tsx
+++ b/src/components/mypage/InterviewHistory.tsx
@@ -250,7 +250,7 @@ export default function InterviewHistory() {
           {/* 수정버튼 */}
           <div className="absolute right-0 top-0">
             <Button onClick={toggleEditMode}>
-              {editMode ? '히스토리 내역 수정' : '히스토리 수정'}
+              {editMode ? '수정 내용 저장하기' : '히스토리 수정'}
             </Button>
           </div>
 


### PR DESCRIPTION
## #️⃣ Issue Number
#136 

## ✏️ 개요
- 히스토리 수정 버튼 텍스트가 사용자가 수정 중인지, 저장 상태인지 헷갈릴 수 있음
- 수정 중 버튼 텍스트를 `수정 내용 저장`으로 수정

## 🛠️ PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [X] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸 스크린샷 (선택)

## 💬 공유사항


## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.  [Commit message convention 참고](https://www.notion.so/goormkdx/214c0ff4ce31802c8b91fcad2e545fc4?source=copy_link#238c0ff4ce31806594e2fcfe9b212619)  (Ctrl + 클릭하세요.) 
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
