### PR TITLE
fix #133 - 추가/ 면접 질문 중복 이슈 해결 

### DIFF
--- a/src/api/questionAPI.ts
+++ b/src/api/questionAPI.ts
@@ -1,18 +1,19 @@
 import { supabase } from '../supabaseClient';
 
-// 카테고리와 토픽별로 질문 받아오는 API
+// 카테고리와 토픽별로 질문 받아오는 API (중복 ID 제외)
 export const getQuestionsByCategoryAndTopic = async (
   category: string,
   topic: string,
-  limit = 4,
+  limit = 3,
+  excludeIds: number[] = [],
 ) => {
-  const { count, error: countError } = await supabase
+  const { count, error: countErr } = await supabase
     .from('questions')
     .select('*', { count: 'exact', head: true })
     .eq('category', category)
     .eq('topic', topic);
 
-  if (countError) throw countError;
+  if (countErr) throw countErr;
 
   const maxOffset = Math.max(0, (count ?? 0) - limit);
   const offset = Math.floor(Math.random() * (maxOffset + 1));
@@ -22,6 +23,7 @@ export const getQuestionsByCategoryAndTopic = async (
     .select('question_id, category, topic, content')
     .eq('category', category)
     .eq('topic', topic)
+    .not('question_id', 'in', `(${excludeIds.join(',') || 0})`)
     .range(offset, offset + limit - 1);
 
   if (error) throw error;

--- a/src/api/questionAPI.ts
+++ b/src/api/questionAPI.ts
@@ -7,23 +7,26 @@ export const getQuestionsByCategoryAndTopic = async (
   limit = 3,
   excludeIds: number[] = [],
 ) => {
+  const excludeList = excludeIds.length ? excludeIds : [0];
+  // 1) 남은 질문 개수부터 구하기,
   const { count, error: countErr } = await supabase
     .from('questions')
     .select('*', { count: 'exact', head: true })
     .eq('category', category)
-    .eq('topic', topic);
-
+    .eq('topic', topic)
+    .not('question_id', 'in', `(${excludeList.join(',')})`);
   if (countErr) throw countErr;
-
+  // 2) 남은 개수 기준으로 Offset
   const maxOffset = Math.max(0, (count ?? 0) - limit);
   const offset = Math.floor(Math.random() * (maxOffset + 1));
 
+  // 3) 실제 데이터 가져올 때 똑같이 excludeIds 적용
   const { data, error } = await supabase
     .from('questions')
     .select('question_id, category, topic, content')
     .eq('category', category)
     .eq('topic', topic)
-    .not('question_id', 'in', `(${excludeIds.join(',') || 0})`)
+    .not('question_id', 'in', `(${excludeIds.join(',')})`)
     .range(offset, offset + limit - 1);
 
   if (error) throw error;

--- a/src/components/interviewpage/FollowUpQuestion.tsx
+++ b/src/components/interviewpage/FollowUpQuestion.tsx
@@ -31,20 +31,28 @@ export default function FolloUpQuestion({
           </H4_placeholder>
         </div>
       </div>
-      {questions.map((q, idx) => (
-        <button
-          key={idx}
-          onClick={() => onSelect(q)}
-          className="w-full text-left my-2 p-2 rounded-lg bg-orange-10 hover:bg-git-bg-tag border border-gray-300 transition cursor-pointer"
-        >
-          <div className="inline-block w-fit border border-gray-300 rounded-full px-3 m-1 text-gray-100">
-            질문 {idx + 1}
-          </div>
-          <H4_placeholder className="text-gray-100 text-sm font-light px-2 py-1">
-            {q.question}
+      {questions.length === 0 ? (
+        <div className="flex justify-center items-center min-h-[120px] m-10 py-10 border border-gray-200 rounded-2xl">
+          <H4_placeholder className="text-center text-g">
+            추가 질문이 없습니다.
           </H4_placeholder>
-        </button>
-      ))}
+        </div>
+      ) : (
+        questions.map((q, idx) => (
+          <button
+            key={idx}
+            onClick={() => onSelect(q)}
+            className="w-full text-left my-2 p-2 rounded-lg bg-orange-10 hover:bg-git-bg-tag border border-gray-300 transition cursor-pointer"
+          >
+            <div className="inline-block w-fit border border-gray-300 rounded-full px-3 m-1 text-gray-100">
+              질문 {idx + 1}
+            </div>
+            <H4_placeholder className="text-gray-100 text-sm font-light px-2 py-1">
+              {q.question}
+            </H4_placeholder>
+          </button>
+        ))
+      )}
     </div>
   );
 }

--- a/src/page/InterviewPage.tsx
+++ b/src/page/InterviewPage.tsx
@@ -115,6 +115,11 @@ export default function InterviewPage() {
 
     const filtered = data.filter((q) => q.question_id !== question.questionId);
 
+    if (filtered.length === 0) {
+      toast('더 이상 추가 질문이 없습니다.', 'info');
+      return;
+    }
+
     setFollowUpQuestions(filtered.map(toQuestionData));
 
     followUpUsedIdsRef.current.push(...filtered.map((q) => q.question_id));
@@ -139,6 +144,21 @@ export default function InterviewPage() {
     }
     await fetchMain();
   };
+
+  // 다음 질문 디바운싱
+  const handleNextDebounced = useMemo(
+    () =>
+      debounce(() => {
+        handleNext();
+      }, 500),
+    [question.questionId],
+  );
+
+  // 추가 질문 디바운싱
+  const debounceToggleFollowUp = useMemo(
+    () => debounce(toggleFollowUp, 500),
+    [showFollowUp, followUpQuestions.length],
+  );
 
   useEffect(() => {
     if (!user_id || !question.questionId) {
@@ -236,7 +256,7 @@ export default function InterviewPage() {
             onFeedback={handleFeedback}
             disabled={showFeedback}
             isFollowUpOpen={showFollowUp}
-            onFollowUpToggle={toggleFollowUp}
+            onFollowUpToggle={debounceToggleFollowUp}
           />
         </div>
 
@@ -263,7 +283,7 @@ export default function InterviewPage() {
           )}
         </div>
         <div className="flex justify-center items-center">
-          <Button className="w-55 h-15 mt-8" onClick={handleNext}>
+          <Button className="w-55 h-15 mt-8" onClick={handleNextDebounced}>
             다음 질문
           </Button>
         </div>


### PR DESCRIPTION
## #️⃣ Issue Number

# 133

## ✏️ 개요

- 질문 중복 이슈 제거
- 추가 질문과 메인 질문 분리하여 각기 다른 질문 출력하게 함 (중복안되게)
- 각 버튼 디바운싱 적용
- 질문 고갈됐을 때 UI 간단하게 구현
+ 질문이 있음에도 불구하고 질문이 없다 라는 이슈 발생,

---
- `mainUsedIdsRef` 로 사용한 ID 저장하여 같은 질문 반복 등장 방지,
- `followUpUsedIdsRef` 를 만들어서 추가 질문 개별 관리,
- count 쿼리에도 excludeIds 반영하여 정확한 남은 질문 개수 기반으로 판단할 수 있게 함.


## 🛠️ PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸 스크린샷 (선택)

## 💬 공유사항
<!--- 논의해야할 부분이 있다면 적어주세요.-->

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  [Commit message convention 참고](https://www.notion.so/goormkdx/214c0ff4ce31802c8b91fcad2e545fc4?source=copy_link#238c0ff4ce31806594e2fcfe9b212619)  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
