### PR TITLE
[refactor/#141] 프로필 사진 삭제 기능 추가

### DIFF
--- a/src/components/mypage/Profile.tsx
+++ b/src/components/mypage/Profile.tsx
@@ -115,6 +115,17 @@ export default function Profile() {
     setSelectedImageFile(file);
   };
 
+  const handleImageDelete = () => {
+    setPreviewImg(defaultProfileImg);
+
+    setFormData((prev) => ({
+      ...prev,
+      profile_img: '',
+    }));
+
+    setSelectedImageFile(null);
+  };
+
   const resetForm = async () => {
     if (!userData) return;
 
@@ -150,7 +161,9 @@ export default function Profile() {
     try {
       const profile_img = selectedImageFile
         ? await uploadUserImageOnly(selectedImageFile, userData.user_id)
-        : userData.profile_img;
+        : formData.profile_img === ''
+          ? ''
+          : userData.profile_img;
 
       await updateUserProfile(userData.user_id, {
         ...formData,
@@ -224,15 +237,28 @@ export default function Profile() {
             alt="프로필 사진"
           />
           {isEditing && (
-            <label className="absolute -bottom-2 left-1/2 -translate-x-1/2 text-xs w-full text-center bg-white border text-gray-500 rounded-full shadow-sm cursor-pointer">
-              사진 변경
-              <input
-                type="file"
-                accept="image/*"
-                className="hidden"
-                onChange={handleImageChange}
-              />
-            </label>
+            <>
+              <label
+                className="absolute -bottom-2 left-1/2 -translate-x-1/2 text-xs w-full text-center bg-white border text-gray-500 rounded-full shadow-sm cursor-pointer 
+              hover:bg-green-10 hover:text-green-500 hover:border-green-500"
+              >
+                사진 변경
+                <input
+                  type="file"
+                  accept="image/*"
+                  className="hidden"
+                  onChange={handleImageChange}
+                />
+              </label>
+              <button
+                type="button"
+                onClick={handleImageDelete}
+                className="absolute -bottom-8 left-1/2 -translate-x-1/2 text-xs w-full text-center bg-white border text-gray-500 rounded-full shadow-sm cursor-pointer
+               hover:bg-red-100 hover:text-red-500 hover:border-red-500"
+              >
+                사진 삭제
+              </button>
+            </>
           )}
         </div>
 


### PR DESCRIPTION
## #️⃣ Issue Number
#141 

## ✏️ 개요
프로필 수정 시 사진 변경을 통해 프로필 사진을 등록할 수 있으나, 기본 이미지로 되돌리는 기능은 없어 프로필 사진 삭제 기능 추가


## 🛠️ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸 스크린샷 (선택)

## 💬 공유사항

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  [Commit message convention 참고](https://www.notion.so/goormkdx/214c0ff4ce31802c8b91fcad2e545fc4?source=copy_link#238c0ff4ce31806594e2fcfe9b212619)  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
