### PR TITLE
fix #161 interview mic locked

### DIFF
--- a/src/components/interviewpage/AnswerInput.tsx
+++ b/src/components/interviewpage/AnswerInput.tsx
@@ -159,7 +159,7 @@ export default function AnswerInput({
 
   const handleMicClick = useCallback(() => {
     if (micLocked) {
-      toast('답변 수정하기 버튼을 눌러 수정 모드로 전환해 주세요.', 'info');
+      toast('[답변 수정하기] 버튼을 눌러 수정 모드로 전환해 주세요.', 'info');
       return;
     }
     if (!voiceRecording) return;
@@ -310,7 +310,6 @@ export default function AnswerInput({
         <button
           type="button"
           onClick={handleMicClick}
-          disabled={micLocked}
           className={`
             absolute bottom-3 right-3 p-1 rounded-full transition cursor-pointer
             ${isRecording ? 'bg-red-500' : 'bg-white hover:bg-gray-200'}
@@ -389,6 +388,15 @@ flex items-center gap-2 border border-gray-200 rounded-xl px-3 py-2 transition
             {editMode && (
               <button
                 onClick={() => {
+                  // 녹음 중이면 녹음 즉시 중단
+                  if (voiceRecordingRef.current?.recording) {
+                    voiceRecordingRef.current.stopRecording();
+                  }
+                  // 타이머도 초기화.
+                  if (timerRef.current) {
+                    clearInterval(timerRef.current);
+                    timerRef.current = null;
+                  }
                   setEditMode(false);
                   setAnswer(editAnswer);
                 }}


### PR DESCRIPTION
## #️⃣ Issue Number

#161 

## ✏️ 개요
- 수정 상태가 아님에도 음성녹음이 가능한 이슈 해결
- '수정 취소하기' 버튼 클릭 시 녹음 중이면 자동으로 녹음 중단되도록 로직 추가


- `micLocked` 조건 강화,  `!editMode` 추가 
editMode 종료 시,
- `voiceRecording.stopRecording()` 호출 및 `timeRef` 도 초기화,

## 🛠️ PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸 스크린샷 (선택)

## 💬 공유사항
<!--- 논의해야할 부분이 있다면 적어주세요.-->

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  [Commit message convention 참고](https://www.notion.so/goormkdx/214c0ff4ce31802c8b91fcad2e545fc4?source=copy_link#238c0ff4ce31806594e2fcfe9b212619)  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
