### PR TITLE
[refactor/#172] 닉네임 수정 취소 후 placeholder 값 초기화

### DIFF
--- a/src/components/adminpage/UserList.tsx
+++ b/src/components/adminpage/UserList.tsx
@@ -54,7 +54,7 @@ export default function UserList({ setView }: setViewType) {
 
   const handleUserSelect = (user: User) => {
     setSelectedUser(user);
-    setEditedNickname(user.nickname);
+    setEditedNickname('');
     setIsEditing(false);
     setActiveTab('info');
   };
@@ -230,7 +230,9 @@ export default function UserList({ setView }: setViewType) {
                           <input
                             type="text"
                             value={editedNickname}
+                            placeholder={selectedUser.nickname}
                             onChange={onChangeName}
+                            maxLength={15}
                             className="px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-slate-500 focus:border-slate-500 transition-all duration-200"
                           />
                           {isNameError && (
@@ -258,7 +260,12 @@ export default function UserList({ setView }: setViewType) {
                     {isEditing ? (
                       <>
                         <Button onClick={handleUpdateUser}>저장</Button>
-                        <Button onClick={() => setIsEditing(false)}>
+                        <Button
+                          onClick={() => {
+                            setIsEditing(false);
+                            setEditedNickname('');
+                          }}
+                        >
                           취소
                         </Button>
                       </>


### PR DESCRIPTION
## #️⃣ Issue Number
#172 

## ✏️ 개요
닉네임 수정 중 취소를 누른 후 다시 수정 시, 이전에 입력했던 미저장 값이 placeholder에 남아 있음
placeholder 값을 현재 사용자의 이름으로 변경하고, 취소를 누르면 input의 value값을 초기화


## 🛠️ PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸 스크린샷 (선택)

## 💬 공유사항
<!--- 논의해야할 부분이 있다면 적어주세요.-->

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  [Commit message convention 참고](https://www.notion.so/goormkdx/214c0ff4ce31802c8b91fcad2e545fc4?source=copy_link#238c0ff4ce31806594e2fcfe9b212619)  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
